### PR TITLE
Create Sphinx documentation for ML Collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+docs/__autosummary
+docs/_build
+docs/make.bat
+dist/
+build/
+*.egg-info
+*.rej
+*~
+\#*\#
+*.pyc
+.DS_Store

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# ML Collections docs
+
+The ML Collections documentation can be found here: TODO(mohitreddy) Add link once the change is pushed.
+
+# How to build the docs
+1. Install the requirements in ml_collections/docs/requirements.txt.
+2. Ensure `pandoc` is installed.
+3. Run `make html` to locally generate documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,69 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'ml_collections'
+copyright = '2020, The ML Collection Authors'
+author = 'The ML Collection Authors'
+
+# The full version, including alpha/beta/rc tags
+release = '0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'nbsphinx',
+    'recommonmark',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+autosummary_generate = True
+
+master_doc = 'index'
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/config_dict.rst
+++ b/docs/config_dict.rst
@@ -1,0 +1,40 @@
+ml_collections.config_dict package
+==================================
+
+.. currentmodule:: ml_collections.config_dict
+
+.. automodule:: ml_collections.config_dict
+
+ConfigDict class
+----------------
+.. autoclass:: ConfigDict
+   :members: __init__, is_type_safe, convert_dict, lock, is_locked, unlock,
+    get, get_oneway_ref, items, iteritems, keys, iterkeys, values, itervalues,
+    eq_as_configdict, to_yaml, to_json, to_json_best_effort, to_dict,
+    copy_and_resolve_references, unlocked, ignore_type, get_type, update,
+    update_from_flattened_dict
+
+FrozenConfigDict class
+----------------------
+.. autoclass:: FrozenConfigDict
+   :members: __init__
+
+FieldReference class
+--------------------
+.. autoclass:: FieldReference
+   :members: __init__, has_cycle, set, empty, get, get_type, identity, to_int,
+    to_float, to_str
+
+Additional Methods
+------------------
+.. autosummary::
+   :toctree: __autosummary
+
+    create
+    placeholder
+    required_placeholder
+    recursive_rename
+    CustomJSONEncoder
+    JSONDecodeError
+    MutabilityError
+    RequiredValueError

--- a/docs/config_dict_examples.rst
+++ b/docs/config_dict_examples.rst
@@ -1,0 +1,12 @@
+ml_collections.config_dict examples
+===================================
+
+.. toctree::
+   :maxdepth: 1
+
+   ConfigDict Basic <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/config_dict_basic.py>
+   ConfigDict Advanced <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/config_dict_advanced.py>
+   ConfigDict Lock <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/config_dict_lock.py>
+   ConfigDict Placeholder <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/config_dict_placeholder.py>
+   Field Reference <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/field_reference.py>
+   FrozenConfigDict <https://github.com/google/ml_collections/blob/master/ml_collections/config_dict/examples/frozen_config_dict.py>

--- a/docs/config_flags.rst
+++ b/docs/config_flags.rst
@@ -1,0 +1,25 @@
+ml_collections.config_flags package
+===================================
+
+.. currentmodule:: ml_collections.config_flags
+
+.. automodule:: ml_collections.config_flags
+
+DEFINE_config_dict
+------------------
+.. automethod:: ml_collections.config_flags.DEFINE_config_dict
+
+DEFINE_config_file
+------------------
+.. automethod:: ml_collections.config_flags.DEFINE_config_file
+
+Additional Methods
+------------------
+.. autosummary::
+   :toctree: __autosummary
+
+   ml_collections.config_flags.config_flags.is_config_flag
+   ml_collections.config_flags.config_flags.GetValue
+   ml_collections.config_flags.config_flags.GetType
+   ml_collections.config_flags.config_flags.GetTypes
+   ml_collections.config_flags.config_flags.SetValue 

--- a/docs/config_flags_examples.rst
+++ b/docs/config_flags_examples.rst
@@ -1,0 +1,8 @@
+ml_collections.config_flags examples
+====================================
+
+.. toctree::
+   :maxdepth: 1
+
+   DEFINE_config_dict <https://github.com/google/ml_collections/blob/master/ml_collections/config_flags/examples/define_config_dict_basic.py>
+   DEFINE_config_file <https://github.com/google/ml_collections/blob/master/ml_collections/config_flags/examples/define_config_file_basic.py>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,36 @@
+.. ml_collections documentation master file, created by
+   sphinx-quickstart on Mon Aug 24 04:09:18 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to ml_collections's documentation!
+==========================================
+
+ML Collections is a library of Python Collections designed for ML use cases.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Quickstart
+
+   README <https://github.com/google/ml_collections/tree/master>
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Examples
+
+   config_dict_examples
+   config_flags_examples
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   config_dict
+   config_flags
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Additional material
+
+   CONTRIBUTING
+   testing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx_rtd_theme
+nbsphinx
+recommonmark

--- a/ml_collections/config_dict/config_dict.py
+++ b/ml_collections/config_dict/config_dict.py
@@ -160,27 +160,26 @@ class _Op(collections.namedtuple('_Op', ['fn', 'args'])):
 class FieldReference(object):
   """Reference to a configuration element.
 
-  Typed configuration element that can take a None default value. Example:
+  Typed configuration element that can take a None default value. Example::
 
-      from ml_collections import config_dict
+    from ml_collections import config_dict
 
-      cfg_field = config_dict.FieldReference(0)
-      cfg = config_dict.ConfigDict({
-          'optional': configdict.FieldReference(None, field_type=str)
-          'field': cfg_field,
-          'nested': {'field': cfg_field}
-      })
+    cfg_field = config_dict.FieldReference(0)
+    cfg = config_dict.ConfigDict({
+        'optional': configdict.FieldReference(None, field_type=str)
+        'field': cfg_field,
+        'nested': {'field': cfg_field}
+    })
 
-      with self.assertRaises(TypeError):
-        cfg.optional = 10  # Raises an error because it's defined as an
-                           # intfield.
+    with self.assertRaises(TypeError):
+      cfg.optional = 10  # Raises an error because it's defined as an
+                          # intfield.
 
-      cfg.field = 1  # Changes the value of both cfg.field and cfg.nested.field.
-      print(cfg)
+    cfg.field = 1  # Changes the value of both cfg.field and cfg.nested.field.
+    print(cfg)
 
-  This class also supports lazy computation. Example:
+  This class also supports lazy computation. Example::
 
-    ```python
     ref = config_dict.FieldReference(0)
 
     # Using ref in a standard operation returns another FieldReference. The new
@@ -193,7 +192,6 @@ class FieldReference(object):
 
     ref.set(-2)  # change ref's value again
     print(ref_plus_ten.get())  # Prints 8 because ref's value is -2
-    ```
   """
 
   def __init__(self, default, field_type=None, op=None, required=False):
@@ -558,7 +556,7 @@ class ConfigDict(object):
   - it has dot-based access as well as dict-style key access,
   - it is type safe (once a value is set one cannot change its type).
 
-  Typical usage eaxmple:
+  Typical usage eaxmple::
 
     from ml_collections import config_dict
 
@@ -571,7 +569,7 @@ class ConfigDict(object):
 
     print(cfg)
 
-  Config dictionaries can also be used to pass named arguments to functions:
+  Config dictionaries can also be used to pass named arguments to functions::
 
       from ml_collections import config_dict
 
@@ -602,13 +600,14 @@ class ConfigDict(object):
     Warning: In most cases, this faithfully reproduces the reference structure
     of initial_dictionary, even if initial_dictionary is self-referencing.
     However, unexpected behavior occurs if self-references are contained within
-    list, tuple, or custom types. For example:
-        d = {}
-        d['a'] = d
-        d['b'] = [d]
-        cd = ConfigDict(d)
-        cd.a    # refers to cd, type ConfigDict. Expected behavior.
-        cd.b    # refers to d, type dict. Unexpected behavior.
+    list, tuple, or custom types. For example::
+      
+      d = {}
+      d['a'] = d
+      d['b'] = [d]
+      cd = ConfigDict(d)
+      cd.a    # refers to cd, type ConfigDict. Expected behavior.
+      cd.b    # refers to d, type dict. Unexpected behavior.
 
     Warning: FieldReference values may be changed. If initial_dictionary
     contains a FieldReference with a value of type dict or FrozenConfigDict,
@@ -616,16 +615,19 @@ class ConfigDict(object):
 
     Args:
       initial_dictionary: May be one of the following:
-          1) dict. In this case, all values of initial_dictionary that are
-             dictionaries are also be converted to ConfigDict. However,
-             dictionaries within values of non-dict type are untouched.
-          2) ConfigDict. In this case, all attributes are uncopied, and only the
-             top-level object (self) is re-addressed. This is the same behavior
-             as Python dict, list, and tuple.
-          3) FrozenConfigDict. In this case, initial_dictionary is converted to
-             a ConfigDict version of the initial dictionary for the
-             FrozenConfigDict (reversing any mutability changes FrozenConfigDict
-             made).
+
+        1) dict. In this case, all values of initial_dictionary that are
+        dictionaries are also be converted to ConfigDict. However,
+        dictionaries within values of non-dict type are untouched.
+
+        2) ConfigDict. In this case, all attributes are uncopied, and only the
+        top-level object (self) is re-addressed. This is the same behavior
+        as Python dict, list, and tuple.
+
+        3) FrozenConfigDict. In this case, initial_dictionary is converted to
+        a ConfigDict version of the initial dictionary for the
+        FrozenConfigDict (reversing any mutability changes FrozenConfigDict
+        made).
       type_safe: If set to True, once an attribute value is assigned, its type
           cannot be overridden without .ignore_type() context manager
           (default: True).
@@ -725,19 +727,17 @@ class ConfigDict(object):
   def get_oneway_ref(self, key):
     """Returns a one-way FieldReference.
 
-    Example:
+    Example::
+      
+      cfg = collections.ConfigDict(dict(a=1))
+      cfg.b = cfg.get_oneway_ref('a')
 
-    ```
-    cfg = collections.ConfigDict(dict(a=1))
-    cfg.b = cfg.get_oneway_ref('a')
+      cfg.a = 2
+      print(cfg.b)  # 2
 
-    cfg.a = 2
-    print(cfg.b)  # 2
-
-    cfg.b = 3
-    print(cfg.a)  # 2 (would have been 3 if using get_ref())
-    print(cfg.b)  # 3
-    ```
+      cfg.b = 3
+      print(cfg.a)  # 2 (would have been 3 if using get_ref())
+      print(cfg.b)  # 3
 
     Args:
       key: Key for field we want to reference.
@@ -1294,55 +1294,55 @@ class ConfigDict(object):
   def update_from_flattened_dict(self, flattened_dict, strip_prefix=''):
     """In-place updates values taken from a flattened dict.
 
-    This allows a potentially nested source `ConfigDict` of the following form:
+    This allows a potentially nested source `ConfigDict` of the following form::
 
-    cfg = ConfigDict({
-        'a': 1,
-        'b': {
-            'c': {
-                'd': 2
-            }
-        }
-    })
+      cfg = ConfigDict({
+          'a': 1,
+          'b': {
+              'c': {
+                  'd': 2
+              }
+          }
+      })
 
     to be updated from a dict containing paths navigating to child items, of the
-    following form:
+    following form::
 
-    updates = {
-        'a': 2,
-        'b.c.d': 3
-    }
+      updates = {
+          'a': 2,
+          'b.c.d': 3
+      }
 
     This filters `paths_dict` to only contain paths starting with
     `strip_prefix` and strips the prefix when applying the update.
 
-    For example, consider we have the following values returned as flags:
+    For example, consider we have the following values returned as flags::
 
-    flags = {
-        'flag1': x,
-        'flag2': y,
-        'config': 'some_file.py',
-        'config.a.b': 1,
-        'config.a.c': 2
-    }
+      flags = {
+          'flag1': x,
+          'flag2': y,
+          'config': 'some_file.py',
+          'config.a.b': 1,
+          'config.a.c': 2
+      }
 
-    config = ConfigDict({
-        'a': {
-            'b': 0,
-            'c': 0
-        }
-    })
+      config = ConfigDict({
+          'a': {
+              'b': 0,
+              'c': 0
+          }
+      })
 
-    config.update_from_flattened_dict(flags, 'config.')
+      config.update_from_flattened_dict(flags, 'config.')
 
-    Then we will now have:
+    Then we will now have::
 
-    config = ConfigDict({
-        'a': {
-            'b': 1,
-            'c': 2
-        }
-    })
+      config = ConfigDict({
+          'a': {
+              'b': 1,
+              'c': 2
+          }
+      })
 
     Args:
       flattened_dict: A mapping (key path) -> value.
@@ -1618,13 +1618,17 @@ class FrozenConfigDict(ConfigDict):
 
     Args:
       initial_dictionary: May be one of the following:
-          1) dict. In this case all values of initial_dictionary that are
-             dictionaries are also converted to FrozenConfigDict. If there are
-             dictionaries contained in lists or tuples, an error is raised.
-          2) ConfigDict. In this case all ConfigDict attributes are also
-             converted to FrozenConfigDict.
-          3) FrozenConfigDict. In this case all attributes are uncopied, and
-             only the top-level object (self) is re-addressed.
+
+        1) dict. In this case all values of initial_dictionary that are
+        dictionaries are also converted to FrozenConfigDict. If there are
+        dictionaries contained in lists or tuples, an error is raised.
+
+        2) ConfigDict. In this case all ConfigDict attributes are also
+        converted to FrozenConfigDict.
+
+        3) FrozenConfigDict. In this case all attributes are uncopied, and
+        only the top-level object (self) is re-addressed.
+
       type_safe: See ConfigDict documentation. Note that this only matters
           if the FrozenConfigDict is converted to ConfigDict at some point.
     """
@@ -1836,23 +1840,23 @@ def create(**kwargs):
   """Creates a `ConfigDict` with the given named arguments as key-value pairs.
 
   This allows for simple dictionaries whose elements can be accessed directly
-  using field access:
+  using field access::
 
-      from ml_collections.config_dict import config_dict
-      point = config_dict.create(x=1, y=2)
-      print(point.x, point.y)
+    from ml_collections.config_dict import config_dict
+    point = config_dict.create(x=1, y=2)
+    print(point.x, point.y)
 
-  This is particularly useful for compactly writing nested configurations:
+  This is particularly useful for compactly writing nested configurations::
 
-      config = config_dict.create(
-          data=config_dict.create(
-              game='freeway',
-              frame_size=100),
-          model=config_dict.create(num_hidden=1000))
+    config = config_dict.create(
+      data=config_dict.create(
+        game='freeway',
+        frame_size=100), 
+      model=config_dict.create(num_hidden=1000))
 
   The reason for the existence of this function is that it simplifies the
   code required for the majority of the use cases of `ConfigDict`, compared
-  to using either `ConfigDict` or `namedtuple`s. Examples of such use cases
+  to using either `ConfigDict` or `namedtuple's`. Examples of such use cases
   include training script configuration, and returning multiple named values.
 
   Args:

--- a/ml_collections/config_flags/config_flags.py
+++ b/ml_collections/config_flags/config_flags.py
@@ -100,95 +100,78 @@ def DEFINE_config_file(  # pylint: disable=g-bad-name
 
   Typical usage example:
 
-  `script.py`:
+  `script.py`::
 
-  ```python
-  ...
-  from absl import flags
-  from ml_collections.config_flags import config_flags
+    from absl import flags
+    from ml_collections.config_flags import config_flags
 
-  FLAGS = flags.FLAGS
-  config_flags.DEFINE_config_file('my_config')
-  ...
+    FLAGS = flags.FLAGS
+    config_flags.DEFINE_config_file('my_config')
 
-  print(FLAGS.my_config)
-  ```
+    print(FLAGS.my_config)
 
-  `config.py`:
+  `config.py`::
 
-  ```python
-  def get_config():
-    return {
-        'field1': 1,
-        'field2': 'tom',
-        'nested': {
-            'field': 2.23,
-        },
-    }
-  ```
+    def get_config():
+      return {
+          'field1': 1,
+          'field2': 'tom',
+          'nested': {
+              'field': 2.23,
+          },
+      }
 
-  The following command:
+  The following command::
 
-  ```
-  python script.py -- --my_config=config.py
-                      --my_config.field1 8
-                      --my_config.nested.field=2.1
-  ```
+    python script.py -- --my_config=config.py
+                        --my_config.field1 8
+                        --my_config.nested.field=2.1
 
-  will print:
+  will print::
 
-  ```
-  {'field1': 8, 'field2': 'tom', 'nested': {'field': 2.1}}
-  ```
+    {'field1': 8, 'field2': 'tom', 'nested': {'field': 2.1}}
 
   It is possible to parameterise the get_config function, allowing it to
   return a differently structured result for different occasions. This is
   particularly useful when setting up hyperparameter sweeps across various
   network architectures.
 
-  `parameterised_config.py`:
+  `parameterised_config.py`::
 
-  ```python
-  def get_config(config_string):
-    possible_configs = {
-        'mlp': {
-            'constructor': 'snt.nets.MLP',
-            'config': {
-                'output_sizes': (128, 128, 1),
-            }
-        },
-        'lstm': {
-            'constructor': 'snt.LSTM',
-            'config': {
-                'hidden_size': 128,
-                'forget_bias': 1.0,
-            }
-        }
-    }
-    return possible_configs[config_string]
-  ```
+    def get_config(config_string):
+      possible_configs = {
+          'mlp': {
+              'constructor': 'snt.nets.MLP',
+              'config': {
+                  'output_sizes': (128, 128, 1),
+              }
+          },
+          'lstm': {
+              'constructor': 'snt.LSTM',
+              'config': {
+                  'hidden_size': 128,
+                  'forget_bias': 1.0,
+              }
+          }
+      }
+      return possible_configs[config_string]
 
   If a colon is present in the command line override for the config file,
   everything to the right of the colon is passed into the get_config function.
-  The following command lines will both function correctly:
+  The following command lines will both function correctly::
 
-  ```
-  python script.py -- --my_config=parameterised_config.py:mlp
-                      --my_config.config.output_sizes="(256,256,1)"
-  ```
+    python script.py -- --my_config=parameterised_config.py:mlp
+                        --my_config.config.output_sizes="(256,256,1)"
 
-  ```
-  python script.py -- --my_config=parameterised_config.py:lstm
-                      --my_config.config.hidden_size=256
-  ```
+  
+    python script.py -- --my_config=parameterised_config.py:lstm
+                        --my_config.config.hidden_size=256
 
   The following will produce an error, as the hidden_size flag does not
-  exist when the "mlp" config_string is provided.
+  exist when the "mlp" config_string is provided::
 
-  ```
-  python script.py -- --my_config=parameterised_config.py:mlp
-                      --my_config.config.hidden_size=256
-  ```
+    python script.py -- --my_config=parameterised_config.py:mlp
+                        --my_config.config.hidden_size=256
 
   Args:
     name: Flag name, optionally including extra config after a colon.
@@ -224,7 +207,7 @@ def DEFINE_config_dict(  # pylint: disable=g-bad-name
     flag_values=FLAGS,
     lock_config=True,
     **kwargs):
-  """Defines flag for inline `ConfigDict`s compatible with absl flags.
+  """Defines flag for inline `ConfigDict's` compatible with absl flags.
 
   Similar to `DEFINE_config_file` except the flag's value should be a
   `ConfigDict` instead of a path to a file containing a `ConfigDict`. After the
@@ -233,46 +216,39 @@ def DEFINE_config_dict(  # pylint: disable=g-bad-name
 
   Typical usage example:
 
-  `script.py`:
+  `script.py`::
 
-  ```python
-  ...
-  from absl import flags
+    from absl import flags
 
-  import ml_collections
-  from ml_collections.config_flags import config_flags
+    import ml_collections
+    from ml_collections.config_flags import config_flags
 
 
-  config = ml_collections.ConfigDict({
-      'field1': 1,
-      'field2': 'tom',
-      'nested': {
-          'field': 2.23,
-      }
-  })
+    config = ml_collections.ConfigDict({
+        'field1': 1,
+        'field2': 'tom',
+        'nested': {
+            'field': 2.23,
+        }
+    })
 
 
-  FLAGS = flags.FLAGS
-  config_flags.DEFINE_config_dict('my_config', config)
-  ...
+    FLAGS = flags.FLAGS
+    config_flags.DEFINE_config_dict('my_config', config)
+    ...
 
-  print(FLAGS.my_config)
-  ```
+    print(FLAGS.my_config)
 
-  The following command:
+  The following command::
 
-  ```
-  python script.py -- --my_config.field1 8
-                      --my_config.nested.field=2.1
-  ```
+    python script.py -- --my_config.field1 8
+                        --my_config.nested.field=2.1
 
-  will print:
+  will print::
 
-  ```
-  field1: 8
-  field2: tom
-  nested: {field: 2.1}
-  ```
+    field1: 8
+    field2: tom
+    nested: {field: 2.1}
 
   Args:
     name: Flag name.


### PR DESCRIPTION
Create Sphinx documentation for the following:

* Examples
* API References
* Contributing
* Testing

Also refactor pydoc for classes and APIs. Without this, sphinx documentation throws warnings/errors.