### PR TITLE
add save_as_json_best_effort method to ConfigDict

### DIFF
--- a/ml_collections/config_dict/config_dict.py
+++ b/ml_collections/config_dict/config_dict.py
@@ -1104,6 +1104,20 @@ class ConfigDict:
     """
     return self._json_dumps_wrapper(cls=_BestEffortCustomJSONEncoder, **kwargs)
 
+  def save_as_json_best_effort(self, file, **kwargs):
+    """Saves a best effort JSON representation of the object to file.
+
+    Args:
+      file: path-like object giving the pathname of the file to be written to
+      **kwargs: Keyword arguments for json.dump. They cannot contain "cls"
+          as this method specifies it on its own.
+
+    Returns:
+      JSON representation of the object.
+    """
+    with open(file, 'w') as f:
+      json.dump(self._fields, f, cls=_BestEffortCustomJSONEncoder, **kwargs)
+
   def to_dict(self, visit_map=None, preserve_field_references=False):
     """Converts ConfigDict to regular dict recursively with valid references.
 


### PR DESCRIPTION
In my use cases it is useful to save realised `ConfigDict`s to disk but AFAIK there is currently no built-in functionality for this. Given the existing JSON serialisation logic it would be a simple addition. Do you think this is a worthwhile addition?
