### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: '3.9'
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: '3.9'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install bazel


### PR DESCRIPTION
It seems that the two GitHub actions are failed.

<img width="441" alt="Screenshot 2023-05-17 at 2 58 40 PM" src="https://github.com/google/ml_collections/assets/1548775/54cf204b-4a60-471e-bbde-0a32092d46ea">

And it seems that they have been failing for a while https://github.com/google/ml_collections/actions

Clicking error messages in the above page, it seems that `actions/setup-python@v2` could not set up Python 3.6 for x64.

```
Run actions/setup-python@v2
Version 3.6 was not found in the local cache
Error: Version 3.[6](https://github.com/google/ml_collections/actions/runs/4935359311/jobs/8821559297#step:3:7) with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

So, I copy-n-pasted the usage of setup-python from https://github.com/actions/setup-python#basic-usage.