### PR TITLE
Fix setup.py packages to avoid installing "docs"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     url='https://github.com/google/ml_collections',
     license='Apache 2.0',
     # Contained modules and scripts.
-    packages=find_namespace_packages(exclude=['*_test.py']),
+    packages=find_namespace_packages(exclude=['*_test.py', 'docs*']),
     install_requires=_parse_requirements('requirements.txt'),
     tests_require=_parse_requirements('requirements-test.txt'),
     python_requires='>=2.6',


### PR DESCRIPTION
This project has unintentionally included `docs` in the packages.
As a result, running `pip install ml_collections` will include them under `site-packages`, and you can import them like `from docs import conf`.

It is a [common pitfall](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages) when using `setuptools.find_namespace_packages()` with flat layouts, and you need to set the excludes appropriately.

#### Steps To Reproduce
1. Prepare a clean Python environment with docker, venv, etc.
`docker run --rm -it python:3.10-slim bash`
2. Install ml_collections
`pip install ml_collections`
3. Check under site-packages
`ls /usr/local/lib/python3.10/site-packages/ | grep docs`
4. Check if the docs can be imported
`python -c 'from docs import conf'`