### PR TITLE
Add support for --flagfile to DEFINE_config_*

### DIFF
--- a/ml_collections/config_flags/config_flags.py
+++ b/ml_collections/config_flags/config_flags.py
@@ -703,6 +703,12 @@ class _ConfigFlag(flags.Flag):
     self._sys_argv = sys_argv
     super(_ConfigFlag, self).__init__(**kwargs)
 
+  def _GetArgv(self):
+      """Lazily fetches sys.argv and expands any potential --flagfile=... arguments."""
+      argv = sys.argv if self._sys_argv is None else self._sys_argv
+      argv = flags.FLAGS.read_flags_from_files(argv, force_gnu=False)
+      return argv
+
   def _GetOverrides(self, argv):
     """Parses the command line arguments for the overrides."""
     overrides = []
@@ -735,8 +741,7 @@ class _ConfigFlag(flags.Flag):
     return self._FindConfigSpecified(argv) >= 0
 
   def _set_default(self, default):
-    if self._IsConfigSpecified(
-        sys.argv if self._sys_argv is None else self._sys_argv):
+    if self._IsConfigSpecified(self._GetArgv()):
       self.default = default
     else:
       super(_ConfigFlag, self)._set_default(default)  # pytype: disable=attribute-error
@@ -766,8 +771,7 @@ class _ConfigFlag(flags.Flag):
     config = super(_ConfigFlag, self)._parse(argument)
 
     # Get list or overrides
-    overrides = self._GetOverrides(
-        sys.argv if self._sys_argv is None else self._sys_argv)
+    overrides = self._GetOverrides(self._GetArgv())
     # Iterate over overridden fields and create valid parsers
     self._override_values = {}
     self._initialize_missing_parent_fields(config, overrides)

--- a/ml_collections/config_flags/tests/config_overriding_test.py
+++ b/ml_collections/config_flags/tests/config_overriding_test.py
@@ -18,6 +18,7 @@ import copy
 import enum
 import shlex
 import sys
+import tempfile
 
 from absl import flags
 from absl.testing import absltest
@@ -830,6 +831,18 @@ class ConfigDictFlagTest(_ConfigFlagTestCase, parameterized.TestCase):
                        serialize_parse('test_config.type_tuple',
                                        values.test_config.type_tuple))
 
+  def testFlagfile(self):
+    config = config_dict.ConfigDict()
+    config.foo = 3
+    config.bar = 4
+
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+      f.write('--test_config.foo=7\n')
+      f.flush()
+      f.close()
+      values = _parse_flags(f'./program --flagfile={f.name}', config=config)
+      self.assertEqual(values.test_config.foo, 7)
+      self.assertEqual(values.test_config.bar, 4)
 
 def main():
   absltest.main()


### PR DESCRIPTION
Because config_flags inspects argv to decide when to call DEFINE_flag, --flagfiles must be evaluated/expanded before inspecting argv.