### PR TITLE
fix missing collections.abc.Mapping inheritance for class ConfigDict

### DIFF
--- a/ml_collections/config_dict/config_dict.py
+++ b/ml_collections/config_dict/config_dict.py
@@ -564,7 +564,7 @@ def _configdict_fill_seed(seed, initial_dictionary, visit_map=None):
     seed.__setattr__(key, value)
 
 
-class ConfigDict:
+class ConfigDict(collections_abc.Mapping):
   # pylint: disable=line-too-long
   """Base class for configuration objects used in DeepMind.
 


### PR DESCRIPTION
This PR makes class `ConfigDict` inherit Python built-in abstract base class `collections.abc.Mapping` so that `isinstance(config_dict_obj, collections.abc.Mapping)` returns True, conforming with Python collection type conventions.

See issue [https://github.com/google/ml_collections/issues/46](https://github.com/google/ml_collections/issues/46)